### PR TITLE
Use a WriteCloser and close the pipe in streams

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -13,12 +13,13 @@ func (d *Daemon) doStreamPipe(c net.Conn, s inet.Stream) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	pipe := func(dst io.Writer, src io.Reader) {
+	pipe := func(dst io.WriteCloser, src io.Reader) {
 		_, err := io.Copy(dst, src)
 		if err != nil && err != io.EOF {
 			log.Debugf("stream error: %s", err.Error())
 			s.Reset()
 		}
+		dst.Close()
 		wg.Done()
 	}
 
@@ -26,7 +27,6 @@ func (d *Daemon) doStreamPipe(c net.Conn, s inet.Stream) {
 	go pipe(s, c)
 
 	wg.Wait()
-	s.Close()
 }
 
 func (d *Daemon) handleStream(s inet.Stream) {


### PR DESCRIPTION
There is a subtle problem with the piping of streams, as closures are not promptly propagated.
This addresses this to close the destination immediately when the copy ends.

Note the impedance mismatch between the directional `inet.Stream.close()` and undirectional `net.Conn.Close()`.
