### PR TITLE
Persistent Daemon Identity

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -1,0 +1,25 @@
+package p2pd
+
+import (
+	"io/ioutil"
+
+	crypto "github.com/libp2p/go-libp2p-crypto"
+)
+
+func ReadIdentity(path string) (crypto.PrivKey, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return crypto.UnmarshalPrivateKey(bytes)
+}
+
+func WriteIdentity(k crypto.PrivKey, path string) error {
+	bytes, err := crypto.MarshalPrivateKey(k)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, bytes, 0500)
+}

--- a/identity.go
+++ b/identity.go
@@ -21,5 +21,5 @@ func WriteIdentity(k crypto.PrivKey, path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, bytes, 0500)
+	return ioutil.WriteFile(path, bytes, 0400)
 }

--- a/p2p-keygen/main.go
+++ b/p2p-keygen/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	p2pd "github.com/libp2p/go-libp2p-daemon"
+
+	crypto "github.com/libp2p/go-libp2p-crypto"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+func main() {
+	file := flag.String("f", "identity", "output key file")
+	ktype := flag.String("t", "rsa", "key type; rsa or ed25519")
+	bits := flag.Int("b", 2048, "key size in bits (for rsa)")
+	flag.Parse()
+
+	var typ int
+
+	switch *ktype {
+	case "rsa":
+		typ = crypto.RSA
+
+	case "ed25519":
+		typ = crypto.Ed25519
+
+	default:
+		log.Fatalf("Unknown key type %s; must be rsa or ed25519", *ktype)
+	}
+
+	priv, pub, err := crypto.GenerateKeyPair(typ, *bits)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	id, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Peer ID: %s\n", id.Pretty())
+
+	err = p2pd.WriteIdentity(priv, *file)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -6,15 +6,28 @@ import (
 	"fmt"
 	"log"
 
+	libp2p "github.com/libp2p/go-libp2p"
 	p2pd "github.com/libp2p/go-libp2p-daemon"
 )
 
 func main() {
 	sock := flag.String("sock", "/tmp/p2pd.sock", "daemon control socket path")
 	quiet := flag.Bool("q", false, "be quiet")
+	id := flag.String("id", "", "peer identity; private key file")
 	flag.Parse()
 
-	d, err := p2pd.NewDaemon(context.Background(), *sock)
+	var opts []libp2p.Option
+
+	if *id != "" {
+		key, err := p2pd.ReadIdentity(*id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		opts = append(opts, libp2p.Identity(key))
+	}
+
+	d, err := p2pd.NewDaemon(context.Background(), *sock, opts...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
       "hash": "Qmda4cPRvSRyox3SqgJN6DfSZGU5TtHufPTp9uXjFj71X6",
       "name": "go-libp2p-peerstore",
       "version": "2.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n",
+      "name": "go-libp2p-crypto",
+      "version": "2.0.1"
     }
   ],
   "gxVersion": "0.12.1",


### PR DESCRIPTION
This adds persistent identities to the daemon, with an `-id` option which accepts a key file.
It also adds a new program, `p2p-keygen` that generates keys for use with the daemon.