### PR TITLE
Change `requestContext` to `d.requestContext`

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -2,7 +2,6 @@ package p2pd
 
 import (
 	"context"
-	"time"
 
 	pb "github.com/libp2p/go-libp2p-daemon/pb"
 
@@ -287,7 +286,7 @@ func (d *Daemon) doDHTProvide(req *pb.DHTRequest) (*pb.Response, <-chan *pb.DHTR
 }
 
 func (d *Daemon) dhtRequestContext(req *pb.DHTRequest) (context.Context, func()) {
-	return requestContext(req.GetTimeout())
+	return d.requestContext(req.GetTimeout())
 }
 
 func dhtResponseBegin() *pb.DHTResponse {


### PR DESCRIPTION
`go build` failed:
```bash
$ go build
# github.com/libp2p/go-libp2p-daemon
./dht.go:5:2: imported and not used: "time"
./dht.go:290:9: undefined: requestContext
```