### PR TITLE
QUIC support

### DIFF
--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -10,6 +10,7 @@ import (
 	libp2p "github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	p2pd "github.com/libp2p/go-libp2p-daemon"
+	quic "github.com/libp2p/go-libp2p-quic-transport"
 	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
@@ -27,6 +28,7 @@ func main() {
 	connMgrLo := flag.Int("connLo", 256, "Connection Manager Low Water mark")
 	connMgrHi := flag.Int("connHi", 512, "Connection Manager High Water mark")
 	connMgrGrace := flag.Duration("connGrace", 120, "Connection Manager grace period (in seconds)")
+	QUIC := flag.Bool("quic", false, "Enables the QUIC transport")
 	flag.Parse()
 
 	var opts []libp2p.Option
@@ -43,6 +45,10 @@ func main() {
 	if *connMgr {
 		cm := connmgr.NewConnManager(*connMgrLo, *connMgrHi, *connMgrGrace)
 		opts = append(opts, libp2p.ConnectionManager(cm))
+	}
+
+	if *QUIC {
+		opts = append(opts, libp2p.DefaultTransports, libp2p.Transport(quic.NewTransport))
 	}
 
 	d, err := p2pd.NewDaemon(context.Background(), *sock, opts...)

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -48,7 +48,15 @@ func main() {
 	}
 
 	if *QUIC {
-		opts = append(opts, libp2p.DefaultTransports, libp2p.Transport(quic.NewTransport))
+		opts = append(opts,
+			libp2p.DefaultTransports,
+			libp2p.Transport(quic.NewTransport),
+			libp2p.ListenAddrStrings(
+				"/ip4/0.0.0.0/tcp/0",
+				"/ip4/0.0.0.0/udp/0/quic",
+				"/ip6/::1/tcp/0",
+				"/ip6/::1/udp/0/quic",
+			))
 	}
 
 	d, err := p2pd.NewDaemon(context.Background(), *sock, opts...)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
       "hash": "QmTSih5JrkhMH62dp1oGjEwcaC38dxXBgRwTbeQEL4mPcU",
       "name": "go-libp2p-connmgr",
       "version": "0.3.23"
+    },
+    {
+      "author": "marten-seemann",
+      "hash": "QmWY1pHdRP1rA2ifUuCu1ZwFJ8ZzpSEcgXsu9haH21AYKd",
+      "name": "go-libp2p-quic-transport",
+      "version": "0.2.13"
     }
   ],
   "gxVersion": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmUDTcnDp2WssbmiDLC6aYurUeyt7QeRakHUQMxA2mZ5iB",
+      "hash": "QmVvV8JQmmqPCwXAaesWJPheUiEFQJ9HWRhWhuFuxVQxpR",
       "name": "go-libp2p",
-      "version": "6.0.23"
+      "version": "6.0.27"
     },
     {
-      "hash": "QmQHnqaNULV8WeUGgh97o9K3KAW6kWQmDyNf9UuikgnPTe",
+      "hash": "QmQsw6Nq2A345PqChdtbWVoYbSno7uqRDHwYmYpbPHmZNc",
       "name": "go-libp2p-kad-dht",
-      "version": "4.4.12"
+      "version": "4.4.16"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTSih5JrkhMH62dp1oGjEwcaC38dxXBgRwTbeQEL4mPcU",
+      "hash": "QmV4Z9ufnVy7tMFHfBnoxbbAxDwFfKNKWtZAbY4CHCp79W",
       "name": "go-libp2p-connmgr",
-      "version": "0.3.23"
+      "version": "0.3.27"
     },
     {
       "author": "marten-seemann",


### PR DESCRIPTION
Adds support for the QUIC transport, enabled with the `-quic` flag.

Closes #33.