### PR TITLE
ipc command & native control interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 #misc
 p2pclient/java/libp2pd.h
 p2pclient/java/p2pd.h
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.a
+*.jnilib
+*.o
+*.class
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+#misc
+p2pclient/java/libp2pd.h
+p2pclient/java/p2pd.h

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,30 @@
-bin: deps
-	go install ./...
+SHELL := /bin/sh
+
+include config.mk
+
+.PHONY : all java-daemon go-daemon daemon-shared-object deps gx clean
+.DEFAULT_GOAL : go-daemon
+
+all: deps go-daemon java-daemon daemon-shared-object
+
+java-daemon:
+	cd $(BDIR) && make $@
+
+daemon-shared-object:
+	cd $(BDIR) && make $@
+
+go-daemon:
+	cd $(DDIR) && go install ./...
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite
 
 gx:
 	go get github.com/whyrusleeping/gx
 	go get github.com/whyrusleeping/gx-go
 
-deps: gx
-	gx --verbose install --global
-	gx-go rewrite
+clean:
+	gx-go uw
+	cd $(BDIR) && make $@
+

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ SHELL := /bin/sh
 
 include config.mk
 
-.PHONY : all java-daemon go-daemon daemon-shared-object deps gx clean
+.PHONY : all java-daemon go-daemon daemon-control-so deps gx clean
 .DEFAULT_GOAL : go-daemon
 
-all: deps go-daemon java-daemon daemon-shared-object
+all: deps go-daemon java-daemon
 
-java-daemon:
+java-daemon: daemon-control-so
 	cd $(BDIR) && make $@
 
-daemon-shared-object:
+daemon-control-so:
 	cd $(BDIR) && make $@
 
 go-daemon:

--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -1,0 +1,42 @@
+SHELL := /bin/sh
+
+include ../config.mk
+
+CC = gcc
+CFLAGS = -O2 -fPIC
+LFLAGS = $(OS_LFLAGS) -shared
+
+JAVA_HOME = $(shell java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | sed 's/\s*java.home = //' | sed 's/\/jre//')
+JAVA_INCLUDES = -I$(JAVA_HOME)/include/$(OS) -I$(JAVA_HOME)/include
+CLASS_PATH = .
+vpath %.class $(CLASS_PATH)
+
+DNAME = p2pd
+
+.PHONY : java-daemon daemon-shared-object clean
+
+java-daemon: daemon-shared-object $(DNAME).class 
+
+daemon-shared-object: lib$(DNAME).$(EXT)
+
+lib%.$(EXT): java-%.o go-%.a
+	$(CC) $(LFLAGS) -o $@ $^
+
+java-%.o: go-%.a
+	$(CC) $(CFLAGS) -c java/java-$*.c $(JAVA_INCLUDES) -o $@
+
+go-p2p.a: 
+	go build -o $@ -buildmode=c-archive main.go
+
+go-%.a: 
+	go build -o $@ -buildmode=c-archive ../$*/main.go
+
+%.class:
+	cd java/examples && javac $*.java && mv $@ ../../$@
+
+clean:
+	rm -f *.o \
+	&& rm -f *.a \
+	&& rm -f *.$(EXT) \
+	&& rm -f *.class \
+	&& rm -f *.h

--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -13,11 +13,11 @@ vpath %.class $(CLASS_PATH)
 
 DNAME = p2pd
 
-.PHONY : java-daemon daemon-shared-object clean
+.PHONY : java-daemon daemon-control-so clean
 
-java-daemon: daemon-shared-object $(DNAME).class 
+java-daemon: $(DNAME).class 
 
-daemon-shared-object: lib$(DNAME).$(EXT)
+daemon-control-so: lib$(DNAME).$(EXT)
 
 lib%.$(EXT): java-%.o go-%.a
 	$(CC) $(LFLAGS) -o $@ $^

--- a/bindings/java/examples/p2pd.java
+++ b/bindings/java/examples/p2pd.java
@@ -1,0 +1,22 @@
+public class p2pd {
+    private static final String NAME = "p2pd"; 
+    public static native void startDaemon(String arg1);
+    public static native void stopDaemon();
+    static {
+        try {
+            
+            System.loadLibrary ( NAME ) ;
+            
+        } catch (UnsatisfiedLinkError e) {
+          System.err.println("Native code library failed to load.\n" + e);
+          System.exit(1);
+        }
+    }
+    public static void main(String[] args) {
+        String parsedArgs = NAME;
+        if( args.length > 0 ){
+            parsedArgs += "|" + String.join("|", args);
+        }
+        startDaemon(parsedArgs);
+    }
+}

--- a/bindings/java/java-p2pd.c
+++ b/bindings/java/java-p2pd.c
@@ -1,0 +1,19 @@
+#include "java-p2pd.h"
+#include "../go-p2pd.h"
+
+JNIEXPORT void JNICALL Java_p2pd_startDaemon (JNIEnv *jenv, jclass jcls, jstring jarg1){
+  char *arg1 = (char *) 0 ;
+  (void)jenv;
+  (void)jcls;
+  arg1 = 0;
+  if (jarg1) {
+    arg1 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg1, 0);
+    if (!arg1) return ;
+  }
+  startDaemon(arg1);
+  if (arg1) (*jenv)->ReleaseStringUTFChars(jenv, jarg1, (const char *)arg1);
+}
+
+JNIEXPORT void JNICALL Java_p2pd_stopDaemon (JNIEnv *jenv, jclass jcls){
+    stopDaemon();
+}

--- a/bindings/java/java-p2pd.h
+++ b/bindings/java/java-p2pd.h
@@ -1,0 +1,16 @@
+#include <jni.h>
+
+#ifndef _Included_p2pd
+#define _Included_p2pd
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL Java_p2pd_startDaemon (JNIEnv *, jclass, jstring);
+
+JNIEXPORT void JNICALL Java_p2pd_stopDaemon (JNIEnv *, jclass);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,12 @@
+OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+ifeq ($(OS), linux)
+	EXT = so
+	OS_LFLAGS =
+else ifeq ($(OS), darwin)
+	EXT = dylib
+	OS_LFLAGS = -mmacosx-version-min=$(shell defaults read loginwindow SystemVersionStampAsString) -framework CoreFoundation -framework Security
+endif
+
+DDIR = p2pd
+BDIR = bindings

--- a/p2pd.go
+++ b/p2pd.go
@@ -1,0 +1,176 @@
+package p2pd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	libp2p "github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	ps "github.com/libp2p/go-libp2p-pubsub"
+	quic "github.com/libp2p/go-libp2p-quic-transport"
+)
+
+// DaemonConfig defines the configuration options
+type DaemonConfig struct {
+	sock                           *string
+	quiet                          *bool
+	id                             *string
+	bootstrap                      *bool
+	bootstrapPeers                 *string
+	dht                            *bool
+	dhtClient                      *bool
+	connMgr                        *bool
+	connMgrLo                      *int
+	connMgrHi                      *int
+	connMgrGrace                   *int
+	QUIC                           *bool
+	natPortMap                     *bool
+	pubsub                         *bool
+	pubsubRouter                   *string
+	pubsubSign                     *bool
+	pubsubSignStrict               *bool
+	gossipsubHeartbeatInterval     *int
+	gossipsubHeartbeatInitialDelay *int
+	args                           []string
+}
+
+func Initialize() DaemonConfig {
+	config := DaemonConfig{
+		sock:                           flag.String("sock", "/tmp/p2pd.sock", "daemon control socket path"),
+		quiet:                          flag.Bool("q", false, "be quiet"),
+		id:                             flag.String("id", "", "peer identity; private key file"),
+		bootstrap:                      flag.Bool("b", false, "connects to bootstrap peers and bootstraps the dht if enabled"),
+		bootstrapPeers:                 flag.String("bootstrapPeers", "", "comma separated list of bootstrap peers; defaults to the IPFS DHT peers"),
+		dht:                            flag.Bool("dht", true, "Enables the DHT in full node mode"),
+		dhtClient:                      flag.Bool("dhtClient", true, "Enables the DHT in client mode"),
+		connMgr:                        flag.Bool("connManager", false, "Enables the Connection Manager"),
+		connMgrLo:                      flag.Int("connLo", 256, "Connection Manager Low Water mark"),
+		connMgrHi:                      flag.Int("connHi", 512, "Connection Manager High Water mark"),
+		connMgrGrace:                   flag.Int("connGrace", 120, "Connection Manager grace period (in seconds)"),
+		QUIC:                           flag.Bool("quic", false, "Enables the QUIC transport"),
+		natPortMap:                     flag.Bool("natPortMap", false, "Enables NAT port mapping"),
+		pubsub:                         flag.Bool("pubsub", false, "Enables pubsub"),
+		pubsubRouter:                   flag.String("pubsubRouter", "gossipsub", "Specifies the pubsub router implementation"),
+		pubsubSign:                     flag.Bool("pubsubSign", true, "Enables pubsub message signing"),
+		pubsubSignStrict:               flag.Bool("pubsubSignStrict", false, "Enables pubsub strict signature verification"),
+		gossipsubHeartbeatInterval:     flag.Int("gossipsubHeartbeatInterval", 0, "Specifies the gossipsub heartbeat interval"),
+		gossipsubHeartbeatInitialDelay: flag.Int("gossipsubHeartbeatInitialDelay", 0, "Specifies the gossipsub initial heartbeat delay"),
+	}
+	flag.Parse()
+	config.args = flag.Args()
+	// delete control socket if it already exists
+	if _, err := os.Stat(*config.sock); !os.IsNotExist(err) {
+		err = os.Remove(*config.sock)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	return config
+}
+
+func Start(config DaemonConfig) {
+	var opts []libp2p.Option
+
+	if *config.id != "" {
+		key, err := ReadIdentity(*config.id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		opts = append(opts, libp2p.Identity(key))
+	}
+
+	if *config.connMgr {
+		cm := connmgr.NewConnManager(*config.connMgrLo, *config.connMgrHi, time.Duration(*config.connMgrGrace))
+		opts = append(opts, libp2p.ConnectionManager(cm))
+	}
+
+	if *config.QUIC {
+		opts = append(opts,
+			libp2p.DefaultTransports,
+			libp2p.Transport(quic.NewTransport),
+			libp2p.ListenAddrStrings(
+				"/ip4/0.0.0.0/tcp/0",
+				"/ip4/0.0.0.0/udp/0/quic",
+				"/ip6/::1/tcp/0",
+				"/ip6/::1/udp/0/quic",
+			))
+	}
+
+	if *config.natPortMap {
+		opts = append(opts, libp2p.NATPortMap())
+	}
+
+	d, err := NewDaemon(context.Background(), *config.sock, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *config.pubsub {
+		if *config.gossipsubHeartbeatInterval > 0 {
+			ps.GossipSubHeartbeatInterval = time.Duration(*config.gossipsubHeartbeatInterval)
+		}
+
+		if *config.gossipsubHeartbeatInitialDelay > 0 {
+			ps.GossipSubHeartbeatInitialDelay = time.Duration(*config.gossipsubHeartbeatInitialDelay)
+		}
+
+		err = d.EnablePubsub(*config.pubsubRouter, *config.pubsubSign, *config.pubsubSignStrict)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *config.dht || *config.dhtClient {
+		err = d.EnableDHT(*config.dhtClient)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *config.bootstrapPeers != "" {
+		BootstrapPeers = strings.Split(*config.bootstrapPeers, ",")
+	}
+
+	if *config.bootstrap {
+		err = d.Bootstrap()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if !*config.quiet {
+		fmt.Printf("Control socket: %s\n", *config.sock)
+		fmt.Printf("Peer ID: %s\n", d.ID().Pretty())
+		fmt.Printf("Peer Addrs:\n")
+		for _, addr := range d.Addrs() {
+			fmt.Printf("%s\n", addr.String())
+		}
+		if *config.bootstrap && *config.bootstrapPeers != "" {
+			fmt.Printf("Bootstrap peers:\n")
+			for _, p := range BootstrapPeers {
+				fmt.Printf("%s\n", p)
+			}
+		}
+	}
+
+	select {}
+}
+
+func Stop() {
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(os.Interrupt)
+}
+
+func ProcessArgs(args *string) DaemonConfig {
+	//replace default config options with configs passed from external source
+	argsArray := strings.Split(*args, "|")
+	os.Args = argsArray
+	//call initialize() to get config
+	config := Initialize()
+	return config
+}

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -1,128 +1,26 @@
 package main
 
+import "C"
 import (
-	"context"
-	"flag"
-	"fmt"
-	"log"
-	"strings"
-
-	libp2p "github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
-	p2pd "github.com/libp2p/go-libp2p-daemon"
-	ps "github.com/libp2p/go-libp2p-pubsub"
-	quic "github.com/libp2p/go-libp2p-quic-transport"
 	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
+
+	p2pd "github.com/libp2p/go-libp2p-daemon"
 )
 
 func main() {
 	identify.ClientVersion = "p2pd/0.1"
+	config := p2pd.Initialize()
+	p2pd.Start(config)
+}
 
-	sock := flag.String("sock", "/tmp/p2pd.sock", "daemon control socket path")
-	quiet := flag.Bool("q", false, "be quiet")
-	id := flag.String("id", "", "peer identity; private key file")
-	bootstrap := flag.Bool("b", false, "connects to bootstrap peers and bootstraps the dht if enabled")
-	bootstrapPeers := flag.String("bootstrapPeers", "", "comma separated list of bootstrap peers; defaults to the IPFS DHT peers")
-	dht := flag.Bool("dht", false, "Enables the DHT in full node mode")
-	dhtClient := flag.Bool("dhtClient", false, "Enables the DHT in client mode")
-	connMgr := flag.Bool("connManager", false, "Enables the Connection Manager")
-	connMgrLo := flag.Int("connLo", 256, "Connection Manager Low Water mark")
-	connMgrHi := flag.Int("connHi", 512, "Connection Manager High Water mark")
-	connMgrGrace := flag.Duration("connGrace", 120, "Connection Manager grace period (in seconds)")
-	QUIC := flag.Bool("quic", false, "Enables the QUIC transport")
-	natPortMap := flag.Bool("natPortMap", false, "Enables NAT port mapping")
-	pubsub := flag.Bool("pubsub", false, "Enables pubsub")
-	pubsubRouter := flag.String("pubsubRouter", "gossipsub", "Specifies the pubsub router implementation")
-	pubsubSign := flag.Bool("pubsubSign", true, "Enables pubsub message signing")
-	pubsubSignStrict := flag.Bool("pubsubSignStrict", false, "Enables pubsub strict signature verification")
-	gossipsubHeartbeatInterval := flag.Duration("gossipsubHeartbeatInterval", 0, "Specifies the gossipsub heartbeat interval")
-	gossipsubHeartbeatInitialDelay := flag.Duration("gossipsubHeartbeatInitialDelay", 0, "Specifies the gossipsub initial heartbeat delay")
-	flag.Parse()
+//export startDaemon
+func startDaemon(args *C.char) {
+	argsGoString := C.GoString(args)
+	config := p2pd.ProcessArgs(&argsGoString)
+	p2pd.Start(config)
+}
 
-	var opts []libp2p.Option
-
-	if *id != "" {
-		key, err := p2pd.ReadIdentity(*id)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		opts = append(opts, libp2p.Identity(key))
-	}
-
-	if *connMgr {
-		cm := connmgr.NewConnManager(*connMgrLo, *connMgrHi, *connMgrGrace)
-		opts = append(opts, libp2p.ConnectionManager(cm))
-	}
-
-	if *QUIC {
-		opts = append(opts,
-			libp2p.DefaultTransports,
-			libp2p.Transport(quic.NewTransport),
-			libp2p.ListenAddrStrings(
-				"/ip4/0.0.0.0/tcp/0",
-				"/ip4/0.0.0.0/udp/0/quic",
-				"/ip6/::1/tcp/0",
-				"/ip6/::1/udp/0/quic",
-			))
-	}
-
-	if *natPortMap {
-		opts = append(opts, libp2p.NATPortMap())
-	}
-
-	d, err := p2pd.NewDaemon(context.Background(), *sock, opts...)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if *pubsub {
-		if *gossipsubHeartbeatInterval > 0 {
-			ps.GossipSubHeartbeatInterval = *gossipsubHeartbeatInterval
-		}
-
-		if *gossipsubHeartbeatInitialDelay > 0 {
-			ps.GossipSubHeartbeatInitialDelay = *gossipsubHeartbeatInitialDelay
-		}
-
-		err = d.EnablePubsub(*pubsubRouter, *pubsubSign, *pubsubSignStrict)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	if *dht || *dhtClient {
-		err = d.EnableDHT(*dhtClient)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	if *bootstrapPeers != "" {
-		p2pd.BootstrapPeers = strings.Split(*bootstrapPeers, ",")
-	}
-
-	if *bootstrap {
-		err = d.Bootstrap()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	if !*quiet {
-		fmt.Printf("Control socket: %s\n", *sock)
-		fmt.Printf("Peer ID: %s\n", d.ID().Pretty())
-		fmt.Printf("Peer Addrs:\n")
-		for _, addr := range d.Addrs() {
-			fmt.Printf("%s\n", addr.String())
-		}
-		if *bootstrap && *bootstrapPeers != "" {
-			fmt.Printf("Bootstrap peers:\n")
-			for _, p := range p2pd.BootstrapPeers {
-				fmt.Printf("%s\n", p)
-			}
-		}
-	}
-
-	select {}
+//export stopDaemon
+func stopDaemon() {
+	p2pd.Stop()
 }


### PR DESCRIPTION
This PR simply packages the libp2p-dameon as a shared object and exposes a simple native control interface with two methods:

- startDaemon(config)
- stopDaemon()

The control interface is still managed via IPC

![beacon chain libp2p interface design option 2](https://user-images.githubusercontent.com/5555162/50317694-824f3780-0482-11e9-8791-1e9fd7caf769.jpg)


### Build Instructions:
```
# build everything
$ make all
# build go daemon
$ make deps && make go-daemon
# build java daemon
$ make deps && make java-daemon
# only build the daemon control shared object 
$ make deps && make daemon-control-so
```

**Run the daemon from Java**

```bash
$ cd bindings && java p2pd
Control socket: /tmp/p2pd.sock
Peer ID: Qmb3mEWb7JGBxzduizmFnzQ14uYaqsFqmsCU4tssMRY3rT
Peer Addrs:
/ip6/::1/tcp/61459
/p2p-circuit
/ip4/127.0.0.1/tcp/61458
/ip4/192.168.1.129/tcp/61458
/ip4/192.168.2.65/tcp/61458 
```
**Run the daemon from Go**

```bash
$ p2pd --sock=/tmp/p2pd2.sock
Control socket: /tmp/p2pd2.sock
Peer ID: Qmbr1NfbBMAzhWTxsJUYu1oXXHhSVRx9BW13qR8uMXuhio
Peer Addrs:
/ip6/::1/tcp/59344
/p2p-circuit
/ip4/127.0.0.1/tcp/59343
/ip4/192.168.1.129/tcp/59343
/ip4/192.168.2.65/tcp/59343
```
