### PR TITLE
Use the DHT bootstrap peer list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 language: go
 
 go:
-- 1.9.x
+- 1.11.x
 
 install:
 - make deps

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -16,7 +16,7 @@ var BootstrapPeers = dht.DefaultBootstrapPeers
 const BootstrapConnections = 4
 
 func bootstrapPeerInfo() ([]*pstore.PeerInfo, error) {
-	var pis []*pstore.PeerInfo
+	pis := make([]*pstore.PeerInfo, 0, len(BootstrapPeers))
 	for _, a := range BootstrapPeers {
 		pi, err := pstore.InfoFromP2pAddr(a)
 		if err != nil {

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -6,45 +6,24 @@ import (
 	"math/rand"
 	"time"
 
+	dht "github.com/libp2p/go-libp2p-kad-dht"
 	inet "github.com/libp2p/go-libp2p-net"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
-	ma "github.com/multiformats/go-multiaddr"
 )
 
-var BootstrapPeers = []string{
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-	"/dnsaddr/bootstrap.libp2p.io/ipfs/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-	"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",            // mars.i.ipfs.io
-	"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",           // pluto.i.ipfs.io
-	"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",           // saturn.i.ipfs.io
-	"/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",             // venus.i.ipfs.io
-	"/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",            // earth.i.ipfs.io
-	"/ip6/2604:a880:1:20::203:d001/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",  // pluto.i.ipfs.io
-	"/ip6/2400:6180:0:d0::151:6001/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",  // saturn.i.ipfs.io
-	"/ip6/2604:a880:800:10::4a:5001/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", // venus.i.ipfs.io
-	"/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd", // earth.i.ipfs.io
-}
+var BootstrapPeers = dht.DefaultBootstrapPeers
 
 const BootstrapConnections = 4
 
 func bootstrapPeerInfo() ([]*pstore.PeerInfo, error) {
-	pis := make([]*pstore.PeerInfo, len(BootstrapPeers))
-	for x, p := range BootstrapPeers {
-		a, err := ma.NewMultiaddr(p)
-		if err != nil {
-			return nil, err
-		}
-
+	var pis []*pstore.PeerInfo
+	for _, a := range BootstrapPeers {
 		pi, err := pstore.InfoFromP2pAddr(a)
 		if err != nil {
 			return nil, err
 		}
-
-		pis[x] = pi
+		pis = append(pis, pi)
 	}
-
 	return pis, nil
 }
 

--- a/daemon.go
+++ b/daemon.go
@@ -35,7 +35,7 @@ type Daemon struct {
 
 func NewDaemon(ctx context.Context, maddr ma.Multiaddr, dhtEnabled bool, dhtClient bool, opts ...libp2p.Option) (*Daemon, error) {
 	d := &Daemon{
-		ctx: ctx,
+		ctx:      ctx,
 		handlers: make(map[proto.ID]ma.Multiaddr),
 	}
 

--- a/p2pclient/p2pclient.go
+++ b/p2pclient/p2pclient.go
@@ -21,7 +21,7 @@ const MessageSizeMax = 1 << 22 // 4 MB
 type Client struct {
 	controlMaddr multiaddr.Multiaddr
 	listenMaddr  multiaddr.Multiaddr
-	listener    manet.Listener
+	listener     manet.Listener
 
 	mhandlers sync.Mutex
 	handlers  map[string]StreamHandlerFunc

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -13,7 +13,7 @@ import (
 	p2pd "github.com/libp2p/go-libp2p-daemon"
 	ps "github.com/libp2p/go-libp2p-pubsub"
 	quic "github.com/libp2p/go-libp2p-quic-transport"
-	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	multiaddr "github.com/multiformats/go-multiaddr"
 )
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -13,7 +13,7 @@ import (
 	p2pd "github.com/libp2p/go-libp2p-daemon"
 	ps "github.com/libp2p/go-libp2p-pubsub"
 	quic "github.com/libp2p/go-libp2p-quic-transport"
-	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	multiaddr "github.com/multiformats/go-multiaddr"
 )
 
@@ -128,7 +128,13 @@ func main() {
 	}
 
 	if *bootstrapPeers != "" {
-		p2pd.BootstrapPeers = strings.Split(*bootstrapPeers, ",")
+		for _, s := range strings.Split(*bootstrapPeers, ",") {
+			ma, err := multiaddr.NewMultiaddr(s)
+			if err != nil {
+				log.Fatalf("error parsing bootstrap peer %q: %v", s, err)
+			}
+			p2pd.BootstrapPeers = append(p2pd.BootstrapPeers, ma)
+		}
 	}
 
 	if *bootstrap {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
       "version": "6.0.30"
     },
     {
-      "hash": "QmNoNExMdWrYSPZDiJJTVmxSh6uKLN26xYVzbLzBLedRcv",
+      "hash": "QmbSCZ2CWbbrT7NY7vdntnF39hnrvGpVbbP1XaP5fwTmvo",
       "name": "go-libp2p-kad-dht",
-      "version": "4.4.19"
+      "version": "4.4.20"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
This uses the default DHT bootstrap list, rather than duplicating it.