### PR TITLE
docs: add LIST_PEERS to control spec

### DIFF
--- a/specs/CONTROL.md
+++ b/specs/CONTROL.md
@@ -121,6 +121,26 @@ Response{
 }
 ```
 
+#### `LIST_PEERS`
+Clients can issue a `LIST_PEERS` request to get a list of IDs of peers the node is connected to.
+
+**Client**
+```
+Request{
+  Type: LIST_PEERS
+}
+```
+
+**Daemon**
+*May return an error*
+
+```
+Response{
+  Type: OK,
+  Peers: [<PeerInfo>, ...]
+}
+```
+
 
 #### `StreamOpen`
 


### PR DESCRIPTION
LIST_PEERS is missing from the Control Spec, this only adds it to the spec, it is already implemented.