### PR TITLE
removes socket on exit

### DIFF
--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	libp2p "github.com/libp2p/go-libp2p"
 	relay "github.com/libp2p/go-libp2p-circuit"
@@ -54,6 +57,19 @@ func pprofHTTP(port int) {
 }
 
 func main() {
+
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
+
+	go func() {
+		sig := <-sigs
+		fmt.Println()
+		fmt.Println(sig)
+		os.Remove("/tmp/p2pd.sock")
+		os.Exit(3)
+	}()
+
 	identify.ClientVersion = "p2pd/0.1"
 
 	maddrString := flag.String("listen", "/unix/tmp/p2pd.sock", "daemon control listen multiaddr")


### PR DESCRIPTION
Removes `/tmp/p2pd.sock` when exiting process.