### PR TITLE
revert go-buffer-pool patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-cid v0.0.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/libp2p/go-buffer-pool v0.0.2-0.20190427103101-96e79a9fe0a7 // indirect
 	github.com/libp2p/go-libp2p v0.0.17
 	github.com/libp2p/go-libp2p-autonat-svc v0.0.5
 	github.com/libp2p/go-libp2p-circuit v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -135,10 +135,6 @@ github.com/libp2p/go-addr-util v0.0.1 h1:TpTQm9cXVRVSKsYbgQ7GKc3KbbHVTnbostgGaDE
 github.com/libp2p/go-addr-util v0.0.1/go.mod h1:4ac6O7n9rIAKB1dnd+s8IbbMXkt+oBpzX4/+RACcnlQ=
 github.com/libp2p/go-buffer-pool v0.0.1 h1:9Rrn/H46cXjaA2HQ5Y8lyhOS1NhTkZ4yuEs2r3Eechg=
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
-github.com/libp2p/go-buffer-pool v0.0.2-0.20190427090243-2f43ac6e6879 h1:icX7mARufUrmdZphrR9T8XqjiifUcUZl3ItTK7nX+6k=
-github.com/libp2p/go-buffer-pool v0.0.2-0.20190427090243-2f43ac6e6879/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
-github.com/libp2p/go-buffer-pool v0.0.2-0.20190427103101-96e79a9fe0a7 h1:TeXCNF2NLpyYoEz7qeXoH9t0Qr5119/0z1fmW4HS/xU=
-github.com/libp2p/go-buffer-pool v0.0.2-0.20190427103101-96e79a9fe0a7/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
 github.com/libp2p/go-conn-security v0.0.1 h1:4kMMrqrt9EUNCNjX1xagSJC+bq16uqjMe9lk1KBMVNs=
 github.com/libp2p/go-conn-security v0.0.1/go.mod h1:bGmu51N0KU9IEjX7kl2PQjgZa40JQWnayTvNMgD/vyk=
 github.com/libp2p/go-conn-security-multistream v0.0.1 h1:XefjAQRHcnUaxKb26RGupToucx3uU4ecbOZ3aACXlDU=


### PR DESCRIPTION
this reverts the go-buffer-pool patches; next round of testing will use a branch to avoid polluting master.