### PR TITLE
feat: add flag for dht server mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ type Security struct {
 
 const DHTFullMode = "full"
 const DHTClientMode = "client"
+const DHTServerMode = "server"
 
 type Config struct {
 	ListenAddr        JSONMaddr
@@ -129,7 +130,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 }
 
 func (c *Config) Validate() error {
-	if c.DHT.Mode != DHTClientMode && c.DHT.Mode != DHTFullMode && c.DHT.Mode != "" {
+	if c.DHT.Mode != DHTClientMode && c.DHT.Mode != DHTFullMode && c.DHT.Mode != DHTServerMode && c.DHT.Mode != "" {
 		return errors.New(fmt.Sprintf("unknown DHT mode %s", c.DHT))
 	}
 	if c.Relay.Auto == true && (c.Relay.Enabled == false || c.DHT.Mode == "") {

--- a/daemon.go
+++ b/daemon.go
@@ -51,6 +51,8 @@ func NewDaemon(ctx context.Context, maddr ma.Multiaddr, dhtMode string, opts ...
 		var dhtOpts []dhtopts.Option
 		if dhtMode == config.DHTClientMode {
 			dhtOpts = append(dhtOpts, dhtopts.Client(true))
+		} else if dhtMode == config.DHTServerMode {
+			dhtOpts = append(dhtOpts, dhtopts.Mode(dht.ModeServer))
 		}
 
 		opts = append(opts, libp2p.Routing(d.DHTRoutingFactory(dhtOpts)))

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -73,6 +73,7 @@ func main() {
 	bootstrapPeers := flag.String("bootstrapPeers", "", "comma separated list of bootstrap peers; defaults to the IPFS DHT peers")
 	dht := flag.Bool("dht", false, "Enables the DHT in full node mode")
 	dhtClient := flag.Bool("dhtClient", false, "Enables the DHT in client mode")
+	dhtServer := flag.Bool("dhtServer", false, "Enables the DHT in server mode (use 'dht' unless you actually need this)")
 	connMgr := flag.Bool("connManager", false, "Enables the Connection Manager")
 	connMgrLo := flag.Int("connLo", 256, "Connection Manager Low Water mark")
 	connMgrHi := flag.Int("connHi", 512, "Connection Manager High Water mark")
@@ -253,6 +254,8 @@ func main() {
 		c.DHT.Mode = config.DHTFullMode
 	} else if *dhtClient {
 		c.DHT.Mode = config.DHTClientMode
+	} else if *dhtServer {
+		c.DHT.Mode = config.DHTServerMode
 	}
 
 	if *pprof {


### PR DESCRIPTION
This adds the ability to set the DHT immediately into server mode, instead of auto or client. This is particularly useful for interop testing for other languages (we're using this for JS/Go testing).

I'm not thrilled about another flag for the dht mode, but this avoids breaking the existing flags.