### PR TITLE
fix: allow using transient connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -240,6 +240,7 @@ func (d *Daemon) doStreamOpen(req *pb.Request) (*pb.Response, network.Stream) {
 	}
 
 	log.Debugf("opening stream", "to", pid)
+	ctx = network.WithUseTransient(ctx, "allow testing over relayed connections")
 	s, err := d.host.NewStream(ctx, pid, protos...)
 	if err != nil {
 		log.Debugw("error opening stream", "to", pid, "error", err)


### PR DESCRIPTION
@MarcoPolo The daemon needs to be able to open transient streams since go-libp2p marks any relayed connection with limits as transient. This is required for running echo over the relay in https://github.com/libp2p/interop/pull/83 . The daemon currently does not support running ping directly.