### PR TITLE
feat: add echo protocol

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	MetricsAddress    string
 	PProf             PProf
 	Security          Security
+	Echo              bool
 }
 
 func (c *Config) UnmarshalJSON(b []byte) error {
@@ -188,5 +189,6 @@ func NewDefaultConfig() Config {
 			Noise: true,
 			TLS:   true,
 		},
+		Echo: false,
 	}
 }

--- a/daemon.go
+++ b/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"io"
 	"os"
 	"sync"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -131,7 +133,17 @@ func (d *Daemon) EnablePubsub(router string, sign, strict bool) error {
 	default:
 		return fmt.Errorf("unknown pubsub router: %s", router)
 	}
+}
 
+func (d *Daemon) EnableEcho() error {
+	d.host.SetStreamHandler("/echo/1.0.0", func(s network.Stream) {
+		if err := doEcho(s); err != nil {
+			s.Reset()
+		} else {
+			s.Close()
+		}
+	})
+	return nil
 }
 
 func (d *Daemon) ID() peer.ID {
@@ -198,4 +210,14 @@ func (d *Daemon) Close() error {
 	}
 
 	return merr.ErrorOrNil()
+}
+
+func doEcho(stream network.Stream) error {
+	_, err := io.Copy(stream, stream)
+
+	if (err == nil) {
+		stream.Close()
+	}
+
+	return err
 }

--- a/daemon.go
+++ b/daemon.go
@@ -137,12 +137,15 @@ func (d *Daemon) EnablePubsub(router string, sign, strict bool) error {
 
 func (d *Daemon) EnableEcho() error {
 	d.host.SetStreamHandler("/echo/1.0.0", func(s network.Stream) {
-		if err := doEcho(s); err != nil {
+		_, err := io.Copy(s, s)
+
+		if err != nil {
 			s.Reset()
 		} else {
 			s.Close()
 		}
 	})
+
 	return nil
 }
 
@@ -210,14 +213,4 @@ func (d *Daemon) Close() error {
 	}
 
 	return merr.ErrorOrNil()
-}
-
-func doEcho(stream network.Stream) error {
-	_, err := io.Copy(stream, stream)
-
-	if err == nil {
-		stream.Close()
-	}
-
-	return err
 }

--- a/daemon.go
+++ b/daemon.go
@@ -215,7 +215,7 @@ func (d *Daemon) Close() error {
 func doEcho(stream network.Stream) error {
 	_, err := io.Copy(stream, stream)
 
-	if (err == nil) {
+	if err == nil {
 		stream.Close()
 	}
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -103,6 +103,7 @@ func main() {
 	forceReachabilityPublic := flag.Bool("forceReachabilityPublic", false, "Set up ForceReachability as public for autonat")
 	forceReachabilityPrivate := flag.Bool("forceReachabilityPrivate", false, "Set up ForceReachability as private for autonat")
 	muxer := flag.String("muxer", "yamux", "muxer to use for connections")
+	echoEnabled := flag.Bool("echo", true, "Enables echo protocol")
 
 	flag.Parse()
 
@@ -206,6 +207,10 @@ func main() {
 
 	if *autonat {
 		c.AutoNat = true
+	}
+
+	if *echoEnabled {
+		c.Echo = true
 	}
 
 	if *pubsub {
@@ -373,6 +378,13 @@ func main() {
 
 	if c.Relay.Enabled {
 		err = d.EnableRelayV2()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if c.Echo {
+		err = d.EnableEcho()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/specs/config.schema.json
+++ b/specs/config.schema.json
@@ -164,6 +164,11 @@
       "default": false,
       "$comment": "Enables the AutoNAT service"
     },
+    "Echo": {
+      "type": "boolean",
+      "default": false,
+      "$comment": "Enables an Echo protocol"
+    },
     "HostAddresses": {
       "type": "array",
       "items": {"$ref": "#/definitions/maddr"},


### PR DESCRIPTION
Adds a `-echo` command line option that enables a simple `/echo/1.0.0` protocol that just echos all received data back to the sender.