### PR TITLE
feat: add webrtc transport

### DIFF
--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -23,9 +23,9 @@ import (
 	connmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
+	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	multiaddr "github.com/multiformats/go-multiaddr"
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
-	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 
 	_ "net/http/pprof"
 )

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -25,6 +25,7 @@ import (
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	multiaddr "github.com/multiformats/go-multiaddr"
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
+	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 
 	_ "net/http/pprof"
 )
@@ -111,6 +112,10 @@ func main() {
 	opts := []libp2p.Option{
 		libp2p.UserAgent("p2pd/0.1"),
 		libp2p.DefaultTransports,
+
+		// needed until webrtc-direct is no longer experimental - this will be in
+		// go-libp2p@0.36.x at the time of writing
+		libp2p.Transport(libp2pwebrtc.New),
 	}
 
 	if *configStdin {


### PR DESCRIPTION
To allow experimenting with webrtc-direct as a listener, add the experimental webrtc transport to the list of supported transports.